### PR TITLE
fix: properly handle FormRequest lifecycle in CRUD controller

### DIFF
--- a/src/CrudController.php
+++ b/src/CrudController.php
@@ -121,8 +121,8 @@ abstract class CrudController extends BaseController
 
     private function handleFormRequestValidation(Request $request, string $requestClass): array
     {
-        if (!is_subclass_of($requestClass, FormRequest::class)) {
-            throw new InvalidArgumentException("Class {$requestClass} must be an instance of " . FormRequest::class);
+        if (! is_subclass_of($requestClass, FormRequest::class)) {
+            throw new InvalidArgumentException("Class {$requestClass} must be an instance of ".FormRequest::class);
         }
 
         /** @var FormRequest $formRequest */
@@ -133,6 +133,7 @@ abstract class CrudController extends BaseController
         $formRequest->setRouteResolver($request->getRouteResolver());
 
         $formRequest->validateResolved();
+
         return $formRequest->validated();
     }
 }


### PR DESCRIPTION
Previously, the CRUD controller was bypassing the FormRequest lifecycle by directly calling `rules()` method, which meant custom FormRequest methods like `withValidator()`, `authorize()`, `prepareForValidation()`, and other lifecycle hooks were being ignored.

This is the PR where I noticed this problem - https://github.com/bisual/backend/pull/444